### PR TITLE
New events signatures fix connected

### DIFF
--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -57,11 +57,11 @@ class Event(object):
     def __init__(self):
         self._connected = {0: set()}
         self.suppress = False
-    
+
     def connected(self, nargs='all'):
         if nargs == 'all':
             ret = set()
-            ret.update(self._connected.itervalues())
+            ret.update(*[v for v in self._connected.itervalues()])
             return ret
         else:
             return self._connected[nargs]

--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -60,7 +60,7 @@ class Events(object):
 class Event(object):
 
     def __init__(self):
-        self._connected = {0: set()}
+        self._connected = {}
         self.suppress = False
 
     def connected(self, nargs=None):

--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -66,7 +66,7 @@ class Event(object):
     def connected(self, nargs=None):
         if nargs is None:
             ret = set()
-            ret.update(*[v for v in self._connected.itervalues()])
+            ret.update(*self._connected.values())
             return ret
         else:
             if nargs in self._connected:

--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -69,7 +69,10 @@ class Event(object):
             ret.update(*[v for v in self._connected.itervalues()])
             return ret
         else:
-            return self._connected[nargs]
+            if nargs in self._connected:
+                return self._connected[nargs]
+            else:
+                return set()
 
     def connect(self, function, nargs='all'):
         if not callable(function):

--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -1,17 +1,20 @@
 import sys
 import inspect
 
+
 class EventSuppressionContext(object):
+
     """
     Context manager for event suppression. When passed an Events class,
     it will suppress all the events in that container when activated by
-    using it in a 'with' statement. The previous suppression state will be 
+    using it in a 'with' statement. The previous suppression state will be
     restored when the 'with' block completes.
     """
+
     def __init__(self, events):
         self.events = events
         self.old = {}
-        
+
     def __enter__(self):
         self.old = {}
         try:
@@ -22,13 +25,15 @@ class EventSuppressionContext(object):
             self.__exit__(*sys.exc_info())
             raise
         return self
-        
+
     def __exit__(self, type, value, tb):
         for e, oldval in self.old.iteritems():
             e.suppress = oldval
         # Never suppress events
 
+
 class Events(object):
+
     """
     Events container.
 
@@ -40,9 +45,9 @@ class Events(object):
     def suppress(self):
         """
         Use this property with a 'with' statement to temporarily suppress all
-        events in the container. When the 'with' vlock completes, the old 
+        events in the container. When the 'with' vlock completes, the old
         suppression values will be restored.
-        
+
         Example usage pattern:
         with obj.events.suppress:
             obj.val_a = a
@@ -95,8 +100,8 @@ class Event(object):
                 else:
                     if len(args) < nargs:
                         raise ValueError(
-                            ("Tried to call %s which require %d args " + \
-                            "with only %d.") % (str(c), nargs, len(args)))
+                            ("Tried to call %s which require %d args " +
+                             "with only %d.") % (str(c), nargs, len(args)))
                     for f in c:
                         f(*args[0:nargs])
 
@@ -104,4 +109,3 @@ class Event(object):
         dc = type(self)()
         memo[id(self)] = dc
         return dc
-            

--- a/hyperspy/events.py
+++ b/hyperspy/events.py
@@ -63,8 +63,8 @@ class Event(object):
         self._connected = {0: set()}
         self.suppress = False
 
-    def connected(self, nargs='all'):
-        if nargs == 'all':
+    def connected(self, nargs=None):
+        if nargs is None:
             ret = set()
             ret.update(*[v for v in self._connected.itervalues()])
             return ret


### PR DESCRIPTION
Fixes a number of issues in `Event.connected`.

There is also a suggested change of syntax. Before `connected(nargs="all")` was returning all the connected functions instead of all the functions that accept all the arguments given to the trigger i.e. it was inconsitent with `connect`. Now, `nargs="all"` returns all the functions that accept all arguments  and `nargs=None` returns all connected functions.