### PR TITLE
Fix slicing by `out` arg when indexing one or more axes

### DIFF
--- a/hyperspy/misc/slicing.py
+++ b/hyperspy/misc/slicing.py
@@ -199,15 +199,16 @@ class FancySlicing(object):
         else:
             out.data = self.data[array_slices]
             _obj = out
-            for slice_, axis_src, axis_dst in zip(
-                    array_slices, self.axes_manager._axes,
-                    out.axes_manager._axes):
+            i = 0
+            for slice_, axis_src in zip(array_slices, self.axes_manager._axes):
                 axis_src = axis_src.copy()
                 if (isinstance(slice_, slice) or
                         len(self.axes_manager._axes) < 2):
                     axis_src._slice_me(slice_)
-                axis_dst.update_from(axis_src, attributes=(
-                    "scale", "offset", "size"))
+                    axis_dst = out.axes_manager._axes[i]
+                    i += 1
+                    axis_dst.update_from(axis_src, attributes=(
+                        "scale", "offset", "size"))
 
         if hasattr(self, "_additional_slicing_targets"):
             for ta in self._additional_slicing_targets:


### PR DESCRIPTION
Don't try to `update_from` for axes that are removed by indexing.