### PR TITLE
Multiple small changes:

### DIFF
--- a/hyperspy/drawing/_widgets/circle.py
+++ b/hyperspy/drawing/_widgets/circle.py
@@ -60,11 +60,14 @@ class CircleWidget(Widget2DBase, ResizersMixin):
         # Changed from base:
         min_sizes = np.array((0.5 * self.axes[0].scale, 0))
         value = np.maximum(value, min_sizes)
-        if self.snap_size:
-            value = self._do_snap_size(value)
-        if np.any(self._size != value):
-            self._size = value
-            self._size_changed()
+        if value[0] < value[1]:
+            self._set_size(value[::-1])
+        else:
+            if self.snap_size:
+                value = self._do_snap_size(value)
+            if np.any(self._size != value):
+                self._size = value
+                self._size_changed()
 
     def increase_size(self):
         """Increment all sizes by one step. Applied via 'size' property.

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -156,8 +156,8 @@ class BaseROI(t.HasTraits):
         return roi
 
     def _parse_axes(self, axes, axes_manager):
-        """Utility function to parse the 'axes' argument to a tuple of
-        DataAxis, and find the matplotlib Axes that contains it.
+        """Utility function to parse the 'axes' argument to a list of
+        DataAxis.
 
         Arguments
         ---------
@@ -177,7 +177,7 @@ class BaseROI(t.HasTraits):
 
         Returns
         -------
-        (tuple(<DataAxis>), matplotlib Axes)
+        [<DataAxis>]
         """
         nd = self.ndim
         axes_out = []
@@ -252,7 +252,7 @@ class BaseInteractiveROI(BaseROI):
                 self._update_widgets()
             self.events.changed.trigger(self)
 
-    def _update_widgets(self, exclude=set()):
+    def _update_widgets(self, exclude=None):
         """Internal function for updating the associated widgets to the
         geometry contained in the ROI.
 
@@ -264,6 +264,8 @@ class BaseInteractiveROI(BaseROI):
             excluding the one that was the source for the change, should be
             updated.
         """
+        if exclude is None:
+            exclude = set()
         if not isinstance(exclude, set):
             exclude = set(exclude)
         for w in self.widgets - exclude:
@@ -347,9 +349,8 @@ class BaseInteractiveROI(BaseROI):
                 self.signal_map[signal][1] == axes:
             self.remove_widget(signal)
 
-        if axes is not None:
-            # Set DataAxes
-            widget.axes = axes
+        # Set DataAxes
+        widget.axes = axes
         with widget.events.changed.suppress_callback(self._on_widget_change):
             self._apply_roi2widget(widget)
         if widget.ax is None:
@@ -370,7 +371,7 @@ class BaseInteractiveROI(BaseROI):
         widget.events.changed.disconnect(self._on_widget_change)
         widget.close()
         for signal, w in self.signal_map.iteritems():
-            if w == widget:
+            if w[0] == widget:
                 self.signal_map.pop(signal)
                 break
 
@@ -439,7 +440,7 @@ class Point1DROI(BasePointROI):
             raise ValueError("Could not find valid widget type")
 
     def __repr__(self):
-        return "%s(value=%f)" % (
+        return "%s(value=%g)" % (
             self.__class__.__name__,
             self.value)
 
@@ -476,10 +477,10 @@ class Point2DROI(BasePointROI):
         widget.position = (self.x, self.y)
 
     def _get_widget_type(self, axes, signal):
-        return widgets.DraggableSquare
+        return widgets.SquareWidget
 
     def __repr__(self):
-        return "%s(x=%f, y=%f)" % (
+        return "%s(x=%g, y=%g)" % (
             self.__class__.__name__,
             self.x, self.y)
 
@@ -530,7 +531,7 @@ class SpanROI(BaseInteractiveROI):
         return widgets.RangeWidget
 
     def __repr__(self):
-        return "%s(left=%f, right=%f)" % (
+        return "%s(left=%g, right=%g)" % (
             self.__class__.__name__,
             self.left,
             self.right)
@@ -599,7 +600,7 @@ class RectangularROI(BaseInteractiveROI):
         return widgets.RectangleWidget
 
     def __repr__(self):
-        return "%s(left=%f, top=%f, right=%f, bottom=%f)" % (
+        return "%s(left=%g, top=%g, right=%g, bottom=%g)" % (
             self.__class__.__name__,
             self.left,
             self.top,
@@ -735,13 +736,13 @@ class CircleROI(BaseInteractiveROI):
 
     def __repr__(self):
         if self.r_inner == t.Undefined:
-            return "%s(cx=%f, cy=%f, r=%f)" % (
+            return "%s(cx=%g, cy=%g, r=%g" % (
                 self.__class__.__name__,
                 self.cx,
                 self.cy,
                 self.r)
         else:
-            return "%s(cx=%f, cy=%f, r=%f, r_inner=%f)" % (
+            return "%s(cx=%g, cy=%g, r=%g, r_inner=%g)" % (
                 self.__class__.__name__,
                 self.cx,
                 self.cy,
@@ -957,8 +958,8 @@ class Line2DROI(BaseInteractiveROI):
                                          linewidth=linewidth,
                                          order=order)
         length = np.linalg.norm(np.diff(
-                np.array(((self.x1, self.y1), (self.x2, self.y2))), axis=0),
-                axis=1)[0]
+            np.array(((self.x1, self.y1), (self.x2, self.y2))), axis=0),
+            axis=1)[0]
         axm = signal.axes_manager.deepcopy()
         idx = []
         for ax in axes:
@@ -966,7 +967,7 @@ class Line2DROI(BaseInteractiveROI):
         for i in reversed(sorted(idx)):  # Remove in reversed order
             axm.remove(i)
         axis = DataAxis(len(profile),
-                        scale=length/len(profile),
+                        scale=length / len(profile),
                         units=axes[0].units,
                         navigate=axes[0].navigate)
         axis.axes_manager = axm
@@ -980,7 +981,7 @@ class Line2DROI(BaseInteractiveROI):
         return roi
 
     def __repr__(self):
-        return "%s(x1=%f, y1=%f, x2=%f, y2=%f, linewidth=%f)" % (
+        return "%s(x1=%g, y1=%g, x2=%g, y2=%g, linewidth=%g)" % (
             self.__class__.__name__,
             self.x1,
             self.y1,

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3932,6 +3932,8 @@ class Signal(FancySlicing,
 
         # Basically perform unfolding, but only on data. We don't care about
         # the axes since the function will consume it/them.
+        if not np.iterable(ar_axes):
+            ar_axes = (ar_axes,)
         ar_axes = sorted(ar_axes)
         new_shape = list(self.data.shape)
         for index in ar_axes[1:]:


### PR DESCRIPTION
 - changed printing of roi to `%g` instead of `%f`, better for very large/small values
 - fixed a bug in _remove_widget
 - fixed a bug in _ma_workaround
 - circle widget now always has inner radius <= outer radius (was not obvious how that was an issue without
   ROI)
 - Removed unnecessary/wrong text from _parse_axes
 - removed empty set as default (no mutables as defaults!)
 - removed unnecessary test that was not possible to happen
 - updated DraggableSquare to SquareWidget in ROI