### PR TITLE
Fix typos, quote cleanup_list, quote, recythonize_str

### DIFF
--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -374,7 +374,7 @@ class MVATools(object):
         else:
             return f
 
-    def _plot_loadings(self, loadings, comp_ids=None, calibrate=True,
+    def _plot_loadings(self, loadings, comp_ids, calibrate=True,
                        same_window=None, comp_label=None,
                        with_factors=False, factors=None,
                        cmap=plt.cm.gray, no_nans=False, per_row=3):
@@ -736,7 +736,7 @@ class MVATools(object):
                     s.save(filename)
 
     def plot_decomposition_factors(self,
-                                   comp_ids=None,
+                                   comp_ids,
                                    calibrate=True,
                                    same_window=None,
                                    comp_label='Decomposition factor',
@@ -859,7 +859,7 @@ class MVATools(object):
                                             per_row=per_row)
 
     def plot_decomposition_loadings(self,
-                                    comp_ids=None,
+                                    comp_ids,
                                     calibrate=True,
                                     same_window=None,
                                     comp_label='Decomposition loading',

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -256,7 +256,7 @@ class MVATools(object):
         ----------
 
         comp_ids : None, int, or list of ints
-            if None, returns maps of 3 components.
+            if None, returns maps of all components.
             if int, returns maps of components with ids from 0 to given
             int.
             if list of ints, returns maps of components with ids in
@@ -314,7 +314,7 @@ class MVATools(object):
         if same_window is None:
             same_window = preferences.MachineLearning.same_window
         if comp_ids is None:
-            comp_ids = range(3)
+            comp_ids = range(factors.shape[1])
 
         elif not hasattr(comp_ids, '__iter__'):
             comp_ids = range(comp_ids)
@@ -381,7 +381,7 @@ class MVATools(object):
         if same_window is None:
             same_window = preferences.MachineLearning.same_window
         if comp_ids is None:
-            comp_ids = range(3)
+            comp_ids = range(loadings.shape[0])
 
         elif not hasattr(comp_ids, '__iter__'):
             comp_ids = range(comp_ids)
@@ -479,7 +479,7 @@ class MVATools(object):
 
         # Select the desired factors
         if comp_ids is None:
-            comp_ids = range(3)
+            comp_ids = range(factors.shape[1])
         elif not hasattr(comp_ids, '__iter__'):
             comp_ids = range(comp_ids)
         mask = np.zeros(factors.shape[1], dtype=np.bool)
@@ -626,7 +626,7 @@ class MVATools(object):
                 export_loadings_default_file_format
 
         if comp_ids is None:
-            comp_ids = range(3)
+            comp_ids = range(loadings.shape[0])
         elif not hasattr(comp_ids, '__iter__'):
             comp_ids = range(comp_ids)
         mask = np.zeros(loadings.shape[0], dtype=np.bool)
@@ -747,7 +747,7 @@ class MVATools(object):
         ----------
 
         comp_ids : None, int, or list of ints
-            if None, returns maps of 3 components.
+            if None, returns maps of all components.
             if int, returns maps of components with ids from 0 to given
             int.
             if list of ints, returns maps of components with ids in

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -256,7 +256,7 @@ class MVATools(object):
         ----------
 
         comp_ids : None, int, or list of ints
-            if None, returns maps of all components.
+            if None, returns maps of 3 components.
             if int, returns maps of components with ids from 0 to given
             int.
             if list of ints, returns maps of components with ids in
@@ -314,7 +314,7 @@ class MVATools(object):
         if same_window is None:
             same_window = preferences.MachineLearning.same_window
         if comp_ids is None:
-            comp_ids = range(factors.shape[1])
+            comp_ids = range(3)
 
         elif not hasattr(comp_ids, '__iter__'):
             comp_ids = range(comp_ids)
@@ -381,7 +381,7 @@ class MVATools(object):
         if same_window is None:
             same_window = preferences.MachineLearning.same_window
         if comp_ids is None:
-            comp_ids = range(loadings.shape[0])
+            comp_ids = range(3)
 
         elif not hasattr(comp_ids, '__iter__'):
             comp_ids = range(comp_ids)
@@ -479,7 +479,7 @@ class MVATools(object):
 
         # Select the desired factors
         if comp_ids is None:
-            comp_ids = range(factors.shape[1])
+            comp_ids = range(3)
         elif not hasattr(comp_ids, '__iter__'):
             comp_ids = range(comp_ids)
         mask = np.zeros(factors.shape[1], dtype=np.bool)
@@ -626,7 +626,7 @@ class MVATools(object):
                 export_loadings_default_file_format
 
         if comp_ids is None:
-            comp_ids = range(loadings.shape[0])
+            comp_ids = range(3)
         elif not hasattr(comp_ids, '__iter__'):
             comp_ids = range(comp_ids)
         mask = np.zeros(loadings.shape[0], dtype=np.bool)
@@ -747,7 +747,7 @@ class MVATools(object):
         ----------
 
         comp_ids : None, int, or list of ints
-            if None, returns maps of all components.
+            if None, returns maps of 3 components.
             if int, returns maps of components with ids from 0 to given
             int.
             if list of ints, returns maps of components with ids in

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,6 @@ for leftover in raw_extensions:
                     path +
                     '.cpython-*.so'))
 
-
 def count_c_extensions(extensions):
     c_num = 0
     for extension in extensions:
@@ -182,7 +181,7 @@ Installation will continue in 5 sec...""")
 
 
 # HOOKS ######
-post_checout_hook_file = os.path.join(setup_path, '.git/hooks/post-checkout')
+post_checkout_hook_file = os.path.join(setup_path, '.git/hooks/post-checkout')
 git_dir = os.path.join(setup_path, '.git')
 hook_ignorer = os.path.join(setup_path, '.hook_ignore')
 
@@ -190,7 +189,7 @@ hook_ignorer = os.path.join(setup_path, '.hook_ignore')
 def find_post_checkout_cleanup_line():
     """find the line index in the git post-checkout hooks
     'rm extension1 extension2 ...'"""
-    with open(post_checout_hook_file, 'r') as pchook:
+    with open(post_checkout_hook_file, 'r') as pchook:
         hook_lines = pchook.readlines()
         for i in range(1, len(hook_lines), 1):
             if re.search('#cleanup_cythonized_and_compiled:',
@@ -201,7 +200,7 @@ def find_post_checkout_cleanup_line():
 # after changing branches:
 if os.path.exists(git_dir) and (not os.path.exists(hook_ignorer)):
     exec_str = sys.executable
-    recythonize_str = ' '.join([exec_str,
+    recythonize_str = ' '.join(['"%s"'%exec_str,'"%s"'%
                                 os.path.join(setup_path, 'setup.py'),
                                 'clean --all build_ext --inplace\n'])
     if os.name == 'nt':
@@ -209,29 +208,29 @@ if os.path.exists(git_dir) and (not os.path.exists(hook_ignorer)):
         recythonize_str = recythonize_str.replace('\\', '/')
         for i in range(len(cleanup_list)):
             cleanup_list[i] = cleanup_list[i].replace('\\', '/')
-    if (not os.path.exists(post_checout_hook_file)):
-        with open(post_checout_hook_file, 'w') as pchook:
+    if (not os.path.exists(post_checkout_hook_file)):
+        with open(post_checkout_hook_file, 'w') as pchook:
             pchook.write('#!/bin/sh\n')
             pchook.write('#cleanup_cythonized_and_compiled:\n')
-            pchook.write('rm ' + ' '.join([i for i in cleanup_list]) + '\n')
+            pchook.write('rm ' + ' '.join(['"%s"' % i for i in cleanup_list]) + '\n')
             pchook.write(recythonize_str)
         hook_mode = 0o777  # make it executable
-        os.chmod(post_checout_hook_file, hook_mode)
+        os.chmod(post_checkout_hook_file, hook_mode)
     else:
-        with open(post_checout_hook_file, 'r') as pchook:
+        with open(post_checkout_hook_file, 'r') as pchook:
             hook_lines = pchook.readlines()
         if re.search(r'#!/bin/.*?sh', hook_lines[0]) is not None:
             line_n = find_post_checkout_cleanup_line()
             if line_n is not None:
                 hook_lines[line_n] = 'rm ' + \
-                    ' '.join([i for i in cleanup_list]) + '\n'
+                    ' '.join(['"%s"' % i for i in cleanup_list]) + '\n'
                 hook_lines[line_n + 1] = recythonize_str
             else:
                 hook_lines.append('\n#cleanup_cythonized_and_compiled:\n')
                 hook_lines.append(
-                    'rm ' + ' '.join([i for i in cleanup_list]) + '\n')
+                    'rm ' + ' '.join(['"%s"' % i for i in cleanup_list]) + '\n')
                 hook_lines.append(recythonize_str)
-            with open(post_checout_hook_file, 'w') as pchook:
+            with open(post_checkout_hook_file, 'w') as pchook:
                 pchook.writelines(hook_lines)
 
 


### PR DESCRIPTION
I am not sure if the quote recythonize_str is working 100% correctly, as it still throws a few errors, then runs a fresh clean (maybee that is what it is supposed to do?).  The same cleanup messages do not show on my work computer.  However, I do not have a post-checkout file on my work computer.
None the less, this allows for me to switch between branches now on my home build, and fixes the issue with spaces in the file path.